### PR TITLE
API 엔드포인트 관리 수정

### DIFF
--- a/YOGHEE/Main/Home/HomeTabContainer.swift
+++ b/YOGHEE/Main/Home/HomeTabContainer.swift
@@ -114,16 +114,10 @@ class HomeTabContainer: ObservableObject {
         
         Task { @MainActor in
             do {
-                let url = URL(string: "https://www.yoghee.xyz/api/main/?type=\(state.selectedTrainingMode.apiType)")!
-                let (data, _) = try await URLSession.shared.data(from: url)
-                
-                // 🔍 디버깅: Raw JSON 출력
-                if let jsonString = String(data: data, encoding: .utf8) {
-                    print("📥 API Response JSON:")
-                    print(jsonString)
-                }
-                
-                let response = try JSONDecoder().decode(MainResponse.self, from: data)
+                // APIService를 사용하여 메인 데이터 조회
+                let response = try await APIService.shared.getMainData(
+                    type: state.selectedTrainingMode.apiType
+                )
                 
                 await MainActor.run {
                     self.state.sections = self.createSections(from: response.data)

--- a/YOGHEE/Network/APIService.swift
+++ b/YOGHEE/Network/APIService.swift
@@ -8,7 +8,56 @@ class APIService {
     
     private init() {}
     
-    // GET 요청을 위한 기본 메서드
+    // MARK: - Endpoints
+    private enum Endpoint {
+        case main(type: String)
+        case categoryDetail(categoryId: String)
+        case notifications
+        
+        var path: String {
+            switch self {
+            case .main:
+                return "/api/main/"
+            case .categoryDetail(let id):
+                return "/api/category/\(id)/"
+            case .notifications:
+                return "/api/notifications/"
+            }
+        }
+        
+        var parameters: Parameters? {
+            switch self {
+            case .main(let type):
+                return ["type": type]
+            case .categoryDetail, .notifications:
+                return nil
+            }
+        }
+    }
+    
+    // MARK: - API Methods
+    
+    /// 메인 데이터 조회
+    func getMainData(type: String) async throws -> MainResponse {
+        let endpoint = Endpoint.main(type: type)
+        return try await get(endPoint: endpoint.path, parameters: endpoint.parameters)
+    }
+    
+    /// 카테고리 상세 조회 (추후 개발 예정)
+    func getCategoryDetail(categoryId: String) async throws -> MainResponse {
+        let endpoint = Endpoint.categoryDetail(categoryId: categoryId)
+        return try await get(endPoint: endpoint.path, parameters: endpoint.parameters)
+    }
+    
+    /// 알림 목록 조회 (추후 개발 예정)
+    func getNotifications() async throws -> MainResponse {
+        let endpoint = Endpoint.notifications
+        return try await get(endPoint: endpoint.path, parameters: endpoint.parameters)
+    }
+    
+    // MARK: - Internal Methods
+    
+    /// GET 요청을 위한 기본 메서드 (Extension에서도 사용 가능)
     func get<T: Codable>(endPoint: String, parameters: Parameters? = nil, headers: HTTPHeaders? = nil) async throws -> T {
         let url = baseURL + endPoint
         


### PR DESCRIPTION
- 타입 안전성: 컴파일 타임에 엔드포인트 오류 방지
- 중앙 관리: URL 변경 시 한 곳만 수정
- 가독성: 메서드명으로 의도 명확히 표현
- 일관성: Alamofire 통일 사용 (URLSession 제거)
- 확장성: 새 API 추가가 쉬움
- 디버깅: APIService의 로그가 모든 API 호출에 자동 적용