### PR TITLE
데이터 없어도 weekClasses / todayClasses 노출되도록 수정

### DIFF
--- a/YOGHEE/Main/MyPage/MyPageTabContainer.swift
+++ b/YOGHEE/Main/MyPage/MyPageTabContainer.swift
@@ -320,19 +320,12 @@ class MyPageTabContainer: ObservableObject {
                 
             case .weekClasses:
                 // 요기니 전용 - 이번주 수업
-                if let weekClasses = data.weekClasses,
-                   (weekClasses.weekDay?.isEmpty == false || weekClasses.weekEnd?.isEmpty == false) {
-                    sections.append(.weekClasses(
-                        weekDay: weekClasses.weekDay,
-                        weekEnd: weekClasses.weekEnd
-                    ))
-                }
+                sections.append(.weekClasses(weekDay: data.weekClasses?.weekDay,
+                                             weekEnd: data.weekClasses?.weekEnd))
                 
             case .todayClasses:
                 // 지도자 전용 - 오늘의 수업
-                if let todayClasses = data.todayClasses, !todayClasses.isEmpty {
-                    sections.append(.todayClasses(items: todayClasses))
-                }
+                sections.append(.todayClasses(items: data.todayClasses ?? []))
                 
             case .reservedClasses:
                 // 공통 (요기니: 예약한 수업, 지도자: 예약된 수업)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small UI section-building change that mainly affects empty-state rendering; low risk aside from potential unintended empty sections appearing for some roles.
> 
> **Overview**
> `MyPageTabContainer.createSections` now **always includes** the `.weekClasses` and `.todayClasses` sections when they are present in `availableSections`, even when the API returns no data.
> 
> This removes the previous “only append when non-empty” gating by passing through optional week data and defaulting `todayClasses` to an empty array, ensuring the UI sections still render with empty-state content.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f99527758ac780942c2c519a0b2420abd694f5bf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->